### PR TITLE
HD-381 - Gracefully shutdown kinesis record processor to avoid "Can't update checkpoint - instance doesn't hold the lease for this shard" errors

### DIFF
--- a/external/kinesis-asl/pom.xml
+++ b/external/kinesis-asl/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <!-- Kinesis integration is not included by default due to ASL-licensed code. -->
-  <artifactId>spark-streaming-kinesis-nosto-asl-v2.4_2.11</artifactId>
+  <artifactId>spark-streaming-kinesis-nosto-asl-v2.4_checkpoint_fix_2.11</artifactId>
   <packaging>jar</packaging>
   <name>Spark Kinesis Integration</name>
 

--- a/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisCheckpointer.scala
+++ b/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisCheckpointer.scala
@@ -82,7 +82,7 @@ private[kinesis] class KinesisCheckpointer(
   }
 
   /** Perform the checkpoint. */
-  private def checkpoint(shardId: String, checkpointer: IRecordProcessorCheckpointer): Unit = {
+  def checkpoint(shardId: String, checkpointer: IRecordProcessorCheckpointer): Unit = {
     try {
       if (checkpointer != null) {
         receiver.getLatestSeqNumToCheckpoint(shardId).foreach { latestSeqNum =>
@@ -92,7 +92,7 @@ private[kinesis] class KinesisCheckpointer(
           if (lastSeqNum == null || latestSeqNum > lastSeqNum) {
             /* Perform the checkpoint */
             KinesisRecordProcessor.retryRandom(checkpointer.checkpoint(latestSeqNum), 4, 100)
-            logDebug(s"Checkpoint:  WorkerId $workerId completed checkpoint at sequence number" +
+            logInfo(s"HD-381 - Checkpoint:  WorkerId $workerId completed checkpoint at sequence number" +
               s" $latestSeqNum for shardId $shardId")
             lastCheckpointedSeqNums.put(shardId, latestSeqNum)
           }

--- a/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisCheckpointer.scala
+++ b/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisCheckpointer.scala
@@ -92,7 +92,7 @@ private[kinesis] class KinesisCheckpointer(
           if (lastSeqNum == null || latestSeqNum > lastSeqNum) {
             /* Perform the checkpoint */
             KinesisRecordProcessor.retryRandom(checkpointer.checkpoint(latestSeqNum), 4, 100)
-            logInfo(s"HD-381 - Checkpoint:  WorkerId $workerId completed checkpoint at sequence number" +
+            logWarning(s"HD-381 - Checkpoint:  WorkerId $workerId completed checkpoint at sequence number" +
               s" $latestSeqNum for shardId $shardId")
             lastCheckpointedSeqNums.put(shardId, latestSeqNum)
           }

--- a/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
+++ b/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
@@ -56,7 +56,7 @@ private[kinesis] class KinesisRecordProcessor[T](receiver: KinesisReceiver[T], w
    */
   override def shutdownRequested(iRecordProcessorCheckpointer: IRecordProcessorCheckpointer): Unit = {
     Option(shardId).foreach { shard =>
-      logInfo(s"HD-381 - KinesisRecordProcessor.shutdownRequested called for shard ${shard}")
+      logWarning(s"HD-381 - KinesisRecordProcessor.shutdownRequested called for shard ${shard}")
       // Stop reading Kinesis stream but keep checkpointing
       receiver.onStop(stopCheckpointing = false)
       // Checkpoint immediately instead of relying on scheduled checkpointing in KinesisCheckpointer

--- a/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
+++ b/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
@@ -24,6 +24,7 @@ import scala.util.control.NonFatal
 
 import com.amazonaws.services.kinesis.clientlibrary.exceptions.{InvalidStateException, KinesisClientLibDependencyException, ShutdownException, ThrottlingException}
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.{IRecordProcessor, IRecordProcessorCheckpointer}
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IShutdownNotificationAware
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason
 import com.amazonaws.services.kinesis.model.Record
 
@@ -41,7 +42,28 @@ import org.apache.spark.internal.Logging
  * @param workerId for logging purposes
  */
 private[kinesis] class KinesisRecordProcessor[T](receiver: KinesisReceiver[T], workerId: String, maybeLagMillis: Option[Long])
-  extends IRecordProcessor with Logging {
+  extends IRecordProcessor with IShutdownNotificationAware with Logging {
+
+  /**
+   * Graceful shutdown of Kinesis record processor to avoid
+   * "Can't update checkpoint - instance doesn't hold the lease for this shard" errors.
+   *
+   * See more details from:
+   * - [[https://github.com/awslabs/amazon-kinesis-client/issues/79]]
+   * - [[https://github.com/awslabs/amazon-kinesis-client/pull/109]]
+   *
+   * @param iRecordProcessorCheckpointer
+   */
+  override def shutdownRequested(iRecordProcessorCheckpointer: IRecordProcessorCheckpointer): Unit = {
+    Option(shardId).foreach { shard =>
+      logInfo(s"HD-381 - KinesisRecordProcessor.shutdownRequested called for shard ${shard}")
+      // Stop reading Kinesis stream but keep checkpointing
+      receiver.onStop(stopCheckpointing = false)
+      // Checkpoint immediately instead of relying on scheduled checkpointing in KinesisCheckpointer
+      // because Kinesis record processors will be terminated.
+      receiver.checkpoint(shard, iRecordProcessorCheckpointer)
+    }
+  }
 
   // shardId populated during initialize()
   @volatile


### PR DESCRIPTION
Spark's KinesisRecordProcessor to implement Kinesis IShutdownNotificationAware interface to be notified before processor will be shutdown so that it can update checkpoint before shutdown.

https://nostosolutions.atlassian.net/browse/HD-381

See more details from:
- https://github.com/awslabs/amazon-kinesis-client/issues/79
- https://github.com/awslabs/amazon-kinesis-client/pull/109

**Building**
```
cd external/kinesis-asl
../../dev/change-scala-version.sh 2.11
../../build/mvn -Pyarn -Phadoop-3.0.0 -Dscala-2.11.12 -DskipTests clean package
```

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://spark.apache.org/contributing.html before opening a pull request.
